### PR TITLE
Fix an issue, where player models are IDLE

### DIFF
--- a/lua/weapons/weapon_ghost_base.lua
+++ b/lua/weapons/weapon_ghost_base.lua
@@ -506,8 +506,8 @@ function SWEP:Initialize()
    self:SetDeploySpeed(self.DeploySpeed)
    
    -- compat for gmod update
-   if self.SetWeaponHoldType then
-      self:SetWeaponHoldType(self.HoldType or "pistol")
+   if self.SetHoldType then
+      self:SetHoldType(self.HoldType or "pistol")
    end
 end
 


### PR DESCRIPTION
Fix an issue, where player models are in an IDLE position with the weapon in their hand.
(also spamming "SWEP:SetWeaponHoldType - ActIndex[ "" ] isn't set! (defaulting to normal)" into the console)
https://github.com/Facepunch/garrysmod-issues/issues/1326