### PR TITLE
Fixed a bug causing NPCs to not have a neutral relationship with ghosts

### DIFF
--- a/lua/sv_spectator_deathmatch.lua
+++ b/lua/sv_spectator_deathmatch.lua
@@ -61,9 +61,9 @@ function meta:SetGhost(bool)
 end
 
 function SpecDM:RelationShip(victim)
-	for k,v in pairs(ents.FindByClass("npc_*")) do
-		if v.AddEntityRelationship then
-			v:AddEntityRelationship(v, D_NU, 99)
+	for _, npc in ipairs(ents.FindByClass("npc_*")) do
+		if isfunction(npc.AddEntityRelationship) then
+			npc:AddEntityRelationship(victim, D_NU, 99)
 		end
 	end
 end


### PR DESCRIPTION
A typo was causing the specified NPC to be given a neutral relationship with itself instead of the specified victim.