### PR TITLE
Fix a huge exploit

### DIFF
--- a/lua/sv_specdm_overrides.lua
+++ b/lua/sv_specdm_overrides.lua
@@ -1,6 +1,6 @@
 local old_concommandAdd = concommand.Add
 concommand.Add = function(...)
-	if command == "ttt_spec_use" or command == "ttt_dropweapon" then
+	if ({...})[1] == "ttt_spec_use" or ({...})[1] == "ttt_dropweapon" then
 		local old_func = func
 		func = function(ply, cmd, arg)
 			if IsValid(ply) and ply:IsGhost() then return end
@@ -8,7 +8,7 @@ concommand.Add = function(...)
 		end
 	end
 	return old_concommandAdd(...)
-end
+en
 
 hook.Add("PlayerTraceAttack", "PlayerTraceAttack_SpecDM", function(ply, dmginfo, dir, trace)
 	if ply:IsGhost() then

--- a/lua/sv_specdm_overrides.lua
+++ b/lua/sv_specdm_overrides.lua
@@ -1,6 +1,6 @@
 
 local old_concommandAdd = concommand.Add
-concommand.Add = function(command, func, help)
+concommand.Add = function(command, func, autoComplete, help, flags)
 	if command == "ttt_spec_use" or command == "ttt_dropweapon" then
 		local old_func = func
 		func = function(ply, cmd, arg)
@@ -8,7 +8,7 @@ concommand.Add = function(command, func, help)
 			return old_func(ply, cmd, arg)
 		end
 	end
-	return old_concommandAdd(command, func, help)
+	return old_concommandAdd(command, func, autoComplete, help, flags)
 end
 
 hook.Add("PlayerTraceAttack", "PlayerTraceAttack_SpecDM", function(ply, dmginfo, dir, trace)

--- a/lua/sv_specdm_overrides.lua
+++ b/lua/sv_specdm_overrides.lua
@@ -1,6 +1,5 @@
-
 local old_concommandAdd = concommand.Add
-concommand.Add = function(command, func, autoComplete, help, flags)
+concommand.Add = function(...)
 	if command == "ttt_spec_use" or command == "ttt_dropweapon" then
 		local old_func = func
 		func = function(ply, cmd, arg)
@@ -8,7 +7,7 @@ concommand.Add = function(command, func, autoComplete, help, flags)
 			return old_func(ply, cmd, arg)
 		end
 	end
-	return old_concommandAdd(command, func, autoComplete, help, flags)
+	return old_concommandAdd(...)
 end
 
 hook.Add("PlayerTraceAttack", "PlayerTraceAttack_SpecDM", function(ply, dmginfo, dir, trace)

--- a/lua/sv_specdm_overrides.lua
+++ b/lua/sv_specdm_overrides.lua
@@ -1,14 +1,14 @@
 local old_concommandAdd = concommand.Add
-concommand.Add = function(...)
-	if ({...})[1] == "ttt_spec_use" or ({...})[1] == "ttt_dropweapon" then
+concommand.Add = function(command, func, ...)
+	if command == "ttt_spec_use" or command == "ttt_dropweapon" then
 		local old_func = func
 		func = function(ply, cmd, arg)
 			if IsValid(ply) and ply:IsGhost() then return end
 			return old_func(ply, cmd, arg)
 		end
 	end
-	return old_concommandAdd(...)
-en
+	return old_concommandAdd(command, func, ...)
+end
 
 hook.Add("PlayerTraceAttack", "PlayerTraceAttack_SpecDM", function(ply, dmginfo, dir, trace)
 	if ply:IsGhost() then


### PR DESCRIPTION
Because concommand.Add isn't overwritten with the correct amount of arguments, the FCVAR_CHEAT flag on ttt_force_traitor, terror and detective is never set, allowing players with this addon installed to respawn themselves freely. This patch fixes that.